### PR TITLE
Korrektur OpenAPI, neue Route für GET aller Account-IDs, Fehlerbehebungen

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -14,6 +14,21 @@ schemes:
 - "http"
 paths:
   /accounts:
+    get:
+      tags:
+      - "accounts"
+      summary: "Gibt eine Liste von IDs aller Accounts zurück."
+      produces:
+      - "application/json"
+      responses:
+        "200":
+          description: "Liste der Account-IDs wurde erfolgreich zusammengestellt."
+          schema:
+            $ref: "#/definitions/GetAccounts200"
+        "404":
+          description: "Account wurde nicht gefunden."
+          schema:
+            $ref: "#/definitions/ApiErrorResponse"
     post:
       tags:
       - "accounts"
@@ -417,3 +432,20 @@ definitions:
                 type: "string"
                 example: "1h"
                 description: "Gültigkeitsdauer des Tokens."
+  GetAccounts200:
+    type: "object"
+    properties:
+      code:
+        type: "string"
+        example: "SUCCESS"
+        description: "Ein Code, der zeigt, dass die Anfrage erfolgreich war. Dieser kann ignoriert werden, da man aus dem Statuscode schließen kann, dass es sich um einen Erfolg handelt."
+      devMsg:
+        type: "string"
+        example: ""
+        description: "Eine Nachricht, die Entwicklern zusätzliche Informationen geben kann, aber nicht weiterverarbeitet werden soll. Erfolgreiche Anfragen haben meistens keine Nachricht."
+      content:
+        type: "array"
+        description: "Die Account-IDs."
+        items:
+          type: "integer"
+        example: [32, 59, 44]

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -25,10 +25,6 @@ paths:
           description: "Liste der Account-IDs wurde erfolgreich zusammengestellt."
           schema:
             $ref: "#/definitions/GetAccounts200"
-        "404":
-          description: "Account wurde nicht gefunden."
-          schema:
-            $ref: "#/definitions/ApiErrorResponse"
     post:
       tags:
       - "accounts"

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -4,7 +4,7 @@ info:
   version: "0.0.1"
   title: "Authentification Microservice"
 host: "auth.cyber-city.systems"
-basePath: "/"
+basePath: "/api"
 tags:
 - name: "accounts"
   description: "Funktionen zum Umgang mit Accounts."

--- a/database.js
+++ b/database.js
@@ -2,7 +2,7 @@ const mariadb = require('mariadb');
 
 console.log(
 `Connecting to database with the following information:
-  Host: ${process.env.DB_HOST}
+  Host: ${process.env.DB_HOST}:${process.env.DB_PORT}
   User: ${process.env.DB_USER}
   DB Name: ${process.env.DB_NAME}`
 );
@@ -11,6 +11,7 @@ const db_connect_pool = mariadb.createPool({
     host: process.env.DB_HOST, 
     user: process.env.DB_USER, 
     password: process.env.DB_PASS,
+    port: process.env.DB_PORT,
     connectionLimit: 4,
     database: process.env.DB_NAME
 });

--- a/database.js
+++ b/database.js
@@ -113,6 +113,22 @@ async function getAccountByEmail(account_email)
     return null;
 }
 
+async function getAccountIDs()
+{
+    let accs = await doQuery('SELECT account_id FROM account;');
+
+    if(accs)
+    {
+        const ids = [];
+        for (const entry of accs)
+        {
+            ids.push(entry.account_id);
+        }
+        return ids;
+    }
+    return null;
+}
+
 async function updateRow(table, where, values)
 {
     let query = `UPDATE ${table} SET `;
@@ -144,6 +160,7 @@ module.exports.doQuery = doQuery;
 
 module.exports.getAccountByEmail = getAccountByEmail;
 module.exports.getAccountByID = getAccountByID;
+module.exports.getAccountIDs = getAccountIDs;
 module.exports.registerAccount = registerAccount;
 module.exports.isEmailTaken = isEmailTaken;
 module.exports.getAccountAuthData = getAccountAuthData;

--- a/routes/api/accounts.js
+++ b/routes/api/accounts.js
@@ -86,4 +86,15 @@ router.delete('/', jwtAuth, async (req, res) =>
     res.sendResponse(responses.not_implemented);
 });
 
+router.get('/', async (req, res) =>
+{
+    const accs = await database.getAccountIDs();
+    if(accs)
+    {
+        res.sendResponse(responses.success, '', accs);
+        return;
+    }
+    res.sendResponse(responses.internal_server_error);
+});
+
 module.exports = router;


### PR DESCRIPTION
* Ein paar Fehler in der Swagger-Dokumentation wurden behoben
  * Base-Path wurde zu `/api` angepasst
  * Ein überflüssiger Teil wurde entfernt
* Eine neue Route `GET /api/accounts`
  * Gibt eine Liste mit allen registrierten Account-IDs zurück
  * Erlaubt es den Microservices, ihre Datenbank mit der Authentifizierungs-Datenbank neu zu synchronisieren, z. B. falls es eine Lücke in den Daten gibt
* Der Server sollte nun den Port für die Datenbank aus der Umgebungsvariable `DB_PORT` nehmen